### PR TITLE
Re-write render methods to properly render the content to the DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 
       </header>
       <section class="container">
+        <article class="result" id="article0">
+        </article>
         <article class="result" id="article1">
         </article>
         <article class="result" id="article2">
@@ -52,8 +54,6 @@
         <article class="result" id="article3">
         </article>
         <article class="result" id="article4">
-        </article>
-        <article class="result" id="article5">
         </article>
       </section>
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function handleSubmit(event) {
 
 function getTrailers(movieObj, callback) {
     var movieArray = movieObj.results.slice(0, 5).map(function(movie) {
-        // console.log({title: movie.title, id: movie.id});
         return {
             title: movie.title,
             id: movie.id
@@ -46,7 +45,6 @@ function getTrailers(movieObj, callback) {
             };
             results.push(movie);
             if (movieArray.length === results.length) {
-                console.log(results);
                 callback(results);
             }
         })
@@ -89,28 +87,34 @@ function buildURL(movieTitle) {
 
 //UPDATE DOM MODULE ====================
 
-function renderSummaryAndLink(response) {
-    var summary = response.results[0].summary_short;
-    var link = response.results[0].link.url;
-    var title = response.results[0].display_title;
-    var movieSummary = createOurElement('p', 'result_review');
-    var movieLink = createOurElement('a', 'result_link', link);
-    var movieTitle = createOurElement('h2', 'result_title');
-    var article = document.querySelectorAll('article');
-    console.log(article, 1)
+function compileData(nytRes, tmdbRes, index) {
+    var dataObj = {
+      index: index,
+      title: nytRes.results[0].display_title,
+      summary: nytRes.results[0].summary_short,
+      link: nytRes.results[0].link.url,
+      url: 'https://www.youtube.com/embed/' + tmdbRes.key,
+    }
+    // console.log(dataObj);
 
-    movieSummary.innerHTML = summary;
-    movieLink.innerText = 'Link to review';
-    movieTitle.innerText = title;
-
-    article.forEach(function(item, index){
-      console.log(item, 2);
-      appendToDom(movieSummary, item);
-      appendToDom(movieLink, item);
-      appendToDom(movieTitle, item);
-
-    })
-
+    function renderToDOM(dataObj) {
+      var article = getElement('article' + index);
+      article.innerHTML = '';
+      var movieVideo = createOurElement('iframe', 'result_video', null, dataObj.url);
+      var movieBody = createOurElement('div', 'result_body');
+      var movieTitle = createOurElement('h2', 'result_title');
+      appendToDom(movieTitle, movieBody);
+      movieTitle.textContent = dataObj.title;
+      var movieSummary = createOurElement('p', 'result_review');
+      appendToDom(movieSummary, movieBody);
+      movieSummary.innerHTML = dataObj.summary;
+      var movieLink = createOurElement('a', 'result_link', dataObj.link);
+      appendToDom(movieLink, movieBody);
+      movieLink.textContent = 'Link to review';
+      appendToDom(movieVideo, article);
+      appendToDom(movieBody, article);
+    }
+    renderToDOM(dataObj);
 }
 
 /**
@@ -132,7 +136,7 @@ function appendToDom(element, parent) {
 function createOurElement(element, elClass, href, src) {
     var htmlElement = document.createElement(element);
     if (elClass) {
-        htmlElement.class = elClass;
+        htmlElement.className = elClass;
     }
     if (href) {
         htmlElement.href = href;
@@ -145,20 +149,10 @@ function createOurElement(element, elClass, href, src) {
 
 
 function controller(results) {
-    var iframeArray = [];
-
-    results.map(function(result) {
-        var title = result.title;
-        var key = result.key;
-        iframeArray.push(createOurElement('iframe', title, null, 'https://www.youtube.com/embed/' + result.key));
-        var constructedURL = buildURL(title); //Feed title here//
-        fetch(constructedURL, renderSummaryAndLink);
-
+    results.forEach(function(result, index) {
+        var constructedURL = buildURL(result.title);
+        fetch(constructedURL, function(nytRes) {
+          compileData(nytRes, result, index)
+        });
     });
-    var article = document.querySelectorAll('article');
-
-    iframeArray.forEach(function(iframe, index) {
-      appendToDom(iframe, article[index]);
-    })
-
 }


### PR DESCRIPTION
I rewrote the final part of our callback chain of death to make sure we render everything to the DOM in one place. Previously we were rendering the iframes with the YouTube keys first, then making more API calls to get review data from the NYT.

We are now passing the TMDB data into the callback for the NYT fetch requests, which allows us to render everything at once once we have all the data in a nice clean object.

Relates #21 #38 #39 #40 #48 #52 
